### PR TITLE
Added Ogre token to the default coins list

### DIFF
--- a/src/tokens/ergo.json
+++ b/src/tokens/ergo.json
@@ -63,6 +63,13 @@
       "name": "ErgoPOS",
       "ticker": "EPOS",
       "logoURI": "https://ergopos.io/upload/ergoposlogo.png"
+    },
+    {
+      "address": "6de6f46e5c3eca524d938d822e444b924dbffbe02e5d34bd9dcd4bbfe9e85940",
+      "decimals": 0,
+      "name": "Ogre",
+      "ticker": "Ogre",
+      "logoURI": "https://ogre-token.web.app/assets/ogre.png"
     }
   ]
 }


### PR DESCRIPTION
Ogre token is bringing a large number of new users to Ergo through a social media campaign (10,000+ followers and growing). We are trying to teach users how to use the DEX, but they are getting confused because they can't find the Ogre token in the default list, and they're getting frustrated. These are new users to Spectrum, so they need an easy onboarding experience, and this will help them tremendously.

This PR adds Ogre token to the default list of tokens.

Fixes: https://github.com/ergolabs/default-token-list/issues/13